### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -2569,6 +2569,8 @@ spec:
         - --zap-log-level=${NUTANIX_LOG_LEVEL=info}
         - --zap-devel=${NUTANIX_LOG_DEVELOPMENT=true}
         - --zap-stacktrace-level=${NUTANIX_LOG_STACKTRACE_LEVEL=panic}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -11,3 +11,16 @@ images:
 - name: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller
   newName: registry.ci.openshift.org/openshift
   newTag: nutanix-cluster-api-controllers
+
+patches:
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+- target:
+    kind: Deployment
+    name: capx-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION
This is blocked on Nutanix being integrated in the cluster-capi-operator installer and getting installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Controller manager deployment now supports TLS configuration options, enabling operators to specify minimum TLS version and preferred cipher suites for enhanced security control and compliance requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->